### PR TITLE
[TAS-98] 投稿編集完了後に表示されるモーダル内で自分の投稿一覧に他のユーザーの投稿が表示される

### DIFF
--- a/src/app/create/CreatePostPage.tsx
+++ b/src/app/create/CreatePostPage.tsx
@@ -47,7 +47,7 @@ const CreatePostPage = ({ tags, session }: CreatePostPageProps) => {
         新規投稿
       </h1>
       <FormPost
-        isLoadingSubmit={isLoadingSubmit}
+        isSubmitPending={isLoadingSubmit}
         submit={handleCreatePost}
         session={session}
         tags={tags}

--- a/src/app/edit/[id]/EditPostPage.tsx
+++ b/src/app/edit/[id]/EditPostPage.tsx
@@ -32,7 +32,7 @@ const EditPostPage: FC<EditPostPageProps> = ({ post, tags, session }) => {
     },
     onSuccess: () => {
       toast.success("投稿を編集しました");
-      router.push(`/post/${post.id}`);
+      router.push(`/post/${post.id}/${post.userId}`);
       router.refresh();
     },
   });
@@ -56,12 +56,12 @@ const EditPostPage: FC<EditPostPageProps> = ({ post, tags, session }) => {
           https://zenn.dev/kena/articles/ba26b3245c599a
         */
         key={hash(post)}
-        isLoadingSubmit={isLoadingSubmit}
+        isSubmitPending={isLoadingSubmit}
         submit={handleEditPost}
         initialValue={post}
         session={session}
         tags={tags}
-        isEditing
+        type="edit"
       />
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 投稿編集後の画面で、投稿URLにユーザー情報が含まれるようになり、閲覧時の識別性が向上しました。

- **改善**
  - 投稿フォームの送信状態表示が強化され、送信プロセス中のフィードバックやエラー処理がより分かりやすくなりました。  
  - 送信ボタンのラベルが状況に応じて動的に変更されるようになり、利用体験が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->